### PR TITLE
[feat] Introduce journaling mechanics for quests and dungeons

### DIFF
--- a/core-mechanics.md
+++ b/core-mechanics.md
@@ -66,3 +66,24 @@ There are two primary currencies that define your progress, plus a third for cha
 
 ## Keeper's Loadout
 As a Keeper, you have three starting item slots: one Wearable, one Non-Wearable, and one Familiar. You can only equip one item per slot at a time. The Familiar slot is filled when you befriend a familiar in a dungeon. As you level up, you can unlock more item slots. This loadout lets you tailor your approach each month, adding strategy to how you tackle quests and challenges.
+
+## The Keeper's Journal (Optional Rule)
+
+While The Tome of Secrets can be played as a simple tracker of reading prompts, it shines brightest as a Solo Journaling Game.
+
+### What is a Journaling Game?
+
+A journaling game is a role-playing experience played alone, where the "gameplay" consists of writing entries in a diary or logbook from the perspective of your character. Instead of just ticking a checkbox that says "Quest Complete," you write a few sentences (or paragraphs) describing how your Keeper completed that quest.
+
+**Earn Paper Scraps:** Completing a journal entry for any quest grants you +5 Paper Scraps.
+
+### How to Connect Your Reads
+
+The core creative challenge is tying the Real World Book you read to the In-Game Quest you faced. This connection doesn't always have to be literal. The Grand Library is a place where stories bleed into reality.
+
+Consider these different ways your book might manifest in your journal:
+
+* **The Literal Object:** You physically pull the book from your satchel. Key items referenced in the book might show up in your library.
+* **The Environmental Echo:** The setting of your book overlays the Library. Reading a snowy thriller? The room you enter is inexplicably freezing, covered in frost, or snowing indoors.
+* **The Manifestation:** Elements of the book come to life. A character from the book appears as a ghost or NPC. A mural on the wall depicts the book's plot as if it were ancient history.
+* **The Vibe:** The tone of the book dictates the mood. A horror novel might make the shadows in the Library lengthen and whisper.

--- a/dungeons.md
+++ b/dungeons.md
@@ -8,6 +8,13 @@ Roll a d12 to determine your dungeon room. Each room offers a narrative challeng
 
 **Note:** If you roll a dungeon room that you have already completed (grayed out in the table below), you may roll again. Alternatively, if you have only completed one encounter in a room, you may opt to complete the other encounter instead of re-rolling.
 
+### Journaling: Dungeon Crawls
+
+These are the high-stakes moments of your story. You are venturing into dangerous, unchecked parts of the library to face hostile magical threats. You must weave together the Room, the Creature, and the Book into a narrative.
+
+* **The Setting:** Describe the room. What made it dangerous or unique? How did the room's mechanics physically manifest around you?
+* **The Encounter:** How did the creature appear? Did it crawl out of a book? Did it form from the shadows? Was it friendly or confrontational? What elements of the book impacted the encounter? How did fulfilling the specific prompt translate into something useful for dealing with the creature?
+
 <h3>Dungeon Rewards & Penalties</h3>
 <div id="dungeon-rewards-table"></div>
 

--- a/quests.md
+++ b/quests.md
@@ -30,8 +30,23 @@ Completing an Organize the Stacks quest rewards you with **+15 XP** and **+10 In
     </div>
 </div>
 
+### Journaling: Organize the Stacks
+
+These quests represent the routine duties of a Keeper. You are maintaining your Sanctum, sorting chaotic shelves, discovering lost wings, or simply performing slice-of-life maintenance tasks to keep the magic from overflowing.
+
+* **The Mess:** Why was this section of the library in disarray? How do you go about removing the shroud in this area? Are the books static or do they inexplicably move around?
+* **The Discovery:** Did you find anything unexpected tucked between the pages while cleaning? Did a certain book call to you as you went about your task?
+
 ## ♦️ Atmospheric Buffs (Roll a d8)
 These buffs are daily bonuses. Once per day, when you set a mood for reading, you can earn +1 Ink Drop.
+
+### Journaling: Atmospheric Buffs
+
+These entries focus on the sensory experience of the Library. The Grand Library is an organism with its own weather, moods, and shifts. These entries are about how it feels to exist within the walls.
+
+* **The Senses:** How did this atmospheric change affect your senses? What did the air smell like? Did the warmth of the hearth drive off the winter cold?
+* **The Memory:** Did the atmosphere trigger a memory for your Keeper?
+* **The Effect:** Did the atmosphere make your task harder or easier?
 
 <div id="atmospheric-buffs-table"></div>
 
@@ -39,6 +54,13 @@ These buffs are daily bonuses. Once per day, when you set a mood for reading, yo
 Completing a side quest rewards you with a magical item or a bonus.
 
 **Note:** If you roll a side quest that you have already completed (grayed out in the table below), you may roll again.
+
+### Journaling: Side Quests
+
+These involve interactions with the Library's denizens. You are not alone here; there are ghosts, lost students, magical portraits, and other entities that require your aid.
+
+* **The Encounter:** Who or what did you encounter in the stacks? What problem were they facing or what do they want you to do?
+* **The Result:** How does the book and prompt tie into the encounter? Did the interaction change your relationship with the library? Did you gain a new ally or put a spirit to rest?
 
 <div id="side-quests-table"></div>
 


### PR DESCRIPTION
- Added optional journaling rules for dungeon crawls, organizing stacks, atmospheric buffs, and side quests.
- Expanded on the narrative aspects of gameplay, encouraging players to document their experiences and connections to the library.
- Enhanced the overall depth of the game by integrating storytelling elements into quest and dungeon mechanics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional journaling system with guidance and Paper Scrap rewards, adding journaling sections to core mechanics, dungeons, and quests (stacks, buffs, side quests).
> 
> - **Core Mechanics (`core-mechanics.md`)**:
>   - Add optional rule: **The Keeper's Journal**, defining solo journaling gameplay and how to connect books to quests; grants `+5 Paper Scraps` per journal entry.
>   - Retain and clarify `Keeper's Loadout` description.
> - **Dungeons (`dungeons.md`)**:
>   - Add **Journaling: Dungeon Crawls** section with prompts for setting and encounters.
>   - Initialize tables via `initializeTables()` script.
> - **Quests (`quests.md`)**:
>   - Add journaling sections for **Organize the Stacks**, **Atmospheric Buffs**, and **Side Quests** with focused writing prompts.
>   - No changes to quest mechanics; existing tables and page initialization remain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08fa177995b1b9eac893f873477feb2f611751a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->