### PR TITLE
feat: enhance quest bonus card classification with page count conditions

### DIFF
--- a/assets/css/character-sheet.css
+++ b/assets/css/character-sheet.css
@@ -3659,6 +3659,12 @@
     margin-right: 4px;
 }
 
+.quest-bonus-card-needs-page {
+    color: #888;
+    font-size: 0.85em;
+    font-style: italic;
+}
+
 .no-bonuses-message {
     grid-column: 1 / -1;
     margin: 0;

--- a/assets/js/character-sheet/ui.js
+++ b/assets/js/character-sheet/ui.js
@@ -1324,29 +1324,62 @@ export function renderTemporaryBuffs() {
 }
 
 /**
+ * Extract the first pageCount condition from an item's effects.
+ * @param {Object} item - item or background data object with effects array
+ * @returns {{ min?: number, max?: number } | null}
+ */
+function extractPageCountCondition(item) {
+    if (!item || !Array.isArray(item.effects)) return null;
+    for (const effect of item.effects) {
+        const pc = effect?.condition?.pageCount;
+        if (pc && (typeof pc.min === 'number' || typeof pc.max === 'number')) {
+            return pc;
+        }
+    }
+    return null;
+}
+
+/**
  * Classify a bonus card as 'auto-applied', 'unmatched', or 'subjective'.
  * @param {Object} bonus - bonus object with type, itemData, or backgroundData
  * @param {string[]|null} bookTags - array of tag IDs from the linked book, or null if no book
+ * @param {number|null} bookPageCount - page count of the linked book, or null if unknown
  * @returns {'auto-applied'|'unmatched'|'subjective'}
  */
-export function classifyBonusCardState(bonus, bookTags) {
-    if (bookTags == null) return 'subjective';
+export function classifyBonusCardState(bonus, bookTags, bookPageCount = null) {
+    if (bookTags == null) return 'unmatched';
 
     const effectSource = bonus.type === 'background' ? bonus.backgroundData : bonus.itemData;
     const tagGroups = extractItemTagGroups(effectSource);
+    const pageCountCondition = extractPageCountCondition(effectSource);
 
-    if (tagGroups.length === 0) return 'subjective';
+    // No conditions at all → subjective (always applies, user's choice)
+    if (tagGroups.length === 0 && !pageCountCondition) return 'subjective';
 
-    const matched = tagGroups.some(group =>
-        group.every(tag => bookTags.includes(tag))
-    );
-    return matched ? 'auto-applied' : 'unmatched';
+    // Check if any tagMatch condition is satisfied
+    if (tagGroups.length > 0) {
+        const tagMatched = tagGroups.some(group =>
+            group.every(tag => bookTags.includes(tag))
+        );
+        if (tagMatched) return 'auto-applied';
+    }
+
+    // Check if pageCount condition is satisfied
+    if (pageCountCondition) {
+        if (bookPageCount == null) return 'subjective'; // can't determine without page count
+        let pageMatched = true;
+        if (typeof pageCountCondition.min === 'number' && bookPageCount < pageCountCondition.min) pageMatched = false;
+        if (typeof pageCountCondition.max === 'number' && bookPageCount > pageCountCondition.max) pageMatched = false;
+        if (pageMatched) return 'auto-applied';
+    }
+
+    return 'unmatched';
 }
 
 /**
  * Render a bonus card element
  */
-function createBonusCard(bonus, value, containerId, state = null, bookTags = undefined) {
+function createBonusCard(bonus, value, containerId, state = null, bookTags = undefined, bookPageCount = null) {
     const card = document.createElement('div');
     card.className = 'quest-bonus-card';
     card.dataset.value = value;
@@ -1407,10 +1440,11 @@ function createBonusCard(bonus, value, containerId, state = null, bookTags = und
             updateBonusSelection(containerId);
         });
     } else if (state === 'unmatched') {
-        // Show "Needs:" tag badges for unmatched cards
+        // Show "Needs:" info for unmatched cards
         const effectSource = bonus.type === 'background' ? bonus.backgroundData : bonus.itemData;
         const tagGroups = extractItemTagGroups(effectSource);
-        if (tagGroups.length > 0) {
+        const pageCountCond = extractPageCountCondition(effectSource);
+        if (tagGroups.length > 0 || pageCountCond) {
             const needsDiv = document.createElement('div');
             needsDiv.className = 'quest-bonus-card-needs';
             const needsLabel = document.createElement('span');
@@ -1418,9 +1452,23 @@ function createBonusCard(bonus, value, containerId, state = null, bookTags = und
             needsLabel.textContent = 'Needs:';
             needsDiv.appendChild(needsLabel);
 
-            const badgesEl = renderItemTagBadges(tagGroups, data.bookTags);
-            if (badgesEl) {
-                needsDiv.appendChild(badgesEl);
+            if (tagGroups.length > 0) {
+                const badgesEl = renderItemTagBadges(tagGroups, data.bookTags);
+                if (badgesEl) {
+                    needsDiv.appendChild(badgesEl);
+                }
+            }
+            if (pageCountCond) {
+                const pageLabel = document.createElement('span');
+                pageLabel.className = 'quest-bonus-card-needs-page';
+                if (typeof pageCountCond.min === 'number' && typeof pageCountCond.max === 'number') {
+                    pageLabel.textContent = `${pageCountCond.min}–${pageCountCond.max} pages`;
+                } else if (typeof pageCountCond.min === 'number') {
+                    pageLabel.textContent = `${pageCountCond.min}+ pages`;
+                } else {
+                    pageLabel.textContent = `Under ${pageCountCond.max + 1} pages`;
+                }
+                needsDiv.appendChild(pageLabel);
             }
             card.appendChild(needsDiv);
         }
@@ -1461,7 +1509,7 @@ function updateBonusSelection(containerId) {
 /**
  * Render bonus selection cards for a specific container
  */
-function renderBonusCards(containerId, hiddenInputId, selectedValues = [], bookTags = undefined) {
+function renderBonusCards(containerId, hiddenInputId, selectedValues = [], bookTags = undefined, bookPageCount = null) {
     const container = document.getElementById(containerId);
     const hiddenInput = document.getElementById(hiddenInputId);
     if (!container || !hiddenInput) return;
@@ -1592,8 +1640,8 @@ function renderBonusCards(containerId, hiddenInputId, selectedValues = [], bookT
     
     // Render bonus cards
     bonuses.forEach(bonus => {
-        const state = bookTags !== undefined ? classifyBonusCardState(bonus, bookTags) : null;
-        const card = createBonusCard(bonus, bonus.value, containerId, state, bookTags);
+        const state = bookTags !== undefined ? classifyBonusCardState(bonus, bookTags, bookPageCount) : null;
+        const card = createBonusCard(bonus, bonus.value, containerId, state, bookTags, bookPageCount);
 
         if (state === 'auto-applied') {
             card.classList.add('auto-applied');
@@ -1630,8 +1678,8 @@ export function updateQuestBuffsDropdown(wearableSlotsInput, nonWearableSlotsInp
 /**
  * Update bonus selection for edit quest drawer
  */
-export function updateEditQuestBuffsDropdown(selectedValues = [], bookTags = undefined) {
-    renderBonusCards('edit-quest-bonus-selection-container', 'edit-quest-buffs-select', selectedValues, bookTags);
+export function updateEditQuestBuffsDropdown(selectedValues = [], bookTags = undefined, bookPageCount = null) {
+    renderBonusCards('edit-quest-bonus-selection-container', 'edit-quest-buffs-select', selectedValues, bookTags, bookPageCount);
 }
 
 export function populateBackgroundDropdown() {

--- a/assets/js/controllers/QuestController.js
+++ b/assets/js/controllers/QuestController.js
@@ -1698,15 +1698,17 @@ export class QuestController extends BaseController {
                     // Refresh buff cards to reflect the newly linked book's tags
                     const { ui: uiModule } = this.dependencies;
                     if (uiModule && uiModule.updateEditQuestBuffsDropdown) {
-                        let bookTags;
+                        let bookTags = null;
+                        let bookPageCount = null;
                         if (bookId) {
                             const books = characterState[STORAGE_KEYS.BOOKS];
                             const linkedBook = books && books[bookId];
                             bookTags = Array.isArray(linkedBook?.tags) ? linkedBook.tags : [];
+                            bookPageCount = typeof linkedBook?.pageCount === 'number' ? linkedBook.pageCount : null;
                         }
                         const buffsSelect = document.getElementById('edit-quest-buffs-select');
                         const currentBuffs = buffsSelect && buffsSelect.value ? JSON.parse(buffsSelect.value) : [];
-                        uiModule.updateEditQuestBuffsDropdown(currentBuffs, bookTags);
+                        uiModule.updateEditQuestBuffsDropdown(currentBuffs, bookTags, bookPageCount);
                     }
                 }
             });
@@ -1732,13 +1734,15 @@ export class QuestController extends BaseController {
         // Populate buffs selection (card-based) with book tag awareness
         const { ui: uiModule } = this.dependencies;
         if (uiModule && uiModule.updateEditQuestBuffsDropdown) {
-            let bookTags;
+            let bookTags = null;
+            let bookPageCount = null;
             if (quest.bookId) {
                 const books = characterState[STORAGE_KEYS.BOOKS];
                 const linkedBook = books && books[quest.bookId];
                 bookTags = Array.isArray(linkedBook?.tags) ? linkedBook.tags : [];
+                bookPageCount = typeof linkedBook?.pageCount === 'number' ? linkedBook.pageCount : null;
             }
-            uiModule.updateEditQuestBuffsDropdown(quest.buffs || [], bookTags);
+            uiModule.updateEditQuestBuffsDropdown(quest.buffs || [], bookTags, bookPageCount);
         }
     }
 

--- a/tests/bonusCardState.test.js
+++ b/tests/bonusCardState.test.js
@@ -29,6 +29,26 @@ jest.mock('../assets/js/character-sheet/data.js', () => {
                     condition: { tagMatch: [['series']] },
                     modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 5 }
                 }]
+            },
+            "Bookwyrm's Scale": {
+                name: "Bookwyrm's Scale",
+                bonus: '+10 Ink Drops for long books',
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { min: 500 } },
+                    modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 10 },
+                    slot: 'equipped'
+                }]
+            },
+            'Page Sprite': {
+                name: 'Page Sprite',
+                bonus: 'x2 Ink Drops for short books',
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { max: 299 } },
+                    modifier: { type: 'MULTIPLY', resource: 'inkDrops', value: 2 },
+                    slot: 'equipped'
+                }]
             }
         },
         keeperBackgrounds: {
@@ -105,7 +125,7 @@ describe('classifyBonusCardState', () => {
         expect(classifyBonusCardState(bonus, ['fantasy'])).toBe('subjective');
     });
 
-    test('subjective when bookTags is null (no book linked)', () => {
+    test('unmatched when bookTags is null (no book linked)', () => {
         const bonus = {
             type: 'item',
             itemData: {
@@ -116,7 +136,7 @@ describe('classifyBonusCardState', () => {
                 }]
             }
         };
-        expect(classifyBonusCardState(bonus, null)).toBe('subjective');
+        expect(classifyBonusCardState(bonus, null)).toBe('unmatched');
     });
 
     test('unmatched when bookTags is empty array and item has tagMatch', () => {
@@ -187,6 +207,90 @@ describe('classifyBonusCardState', () => {
             }
         };
         expect(classifyBonusCardState(bonus, ['historical-fiction', 'award-winner'])).toBe('auto-applied');
+    });
+
+    test('auto-applied when pageCount min condition met', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { min: 500 } },
+                    modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 10 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], 600)).toBe('auto-applied');
+    });
+
+    test('unmatched when pageCount min condition not met', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { min: 500 } },
+                    modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 10 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], 300)).toBe('unmatched');
+    });
+
+    test('auto-applied when pageCount max condition met', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { max: 299 } },
+                    modifier: { type: 'MULTIPLY', resource: 'inkDrops', value: 2 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], 250)).toBe('auto-applied');
+    });
+
+    test('unmatched when pageCount max condition not met', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { max: 299 } },
+                    modifier: { type: 'MULTIPLY', resource: 'inkDrops', value: 2 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], 400)).toBe('unmatched');
+    });
+
+    test('subjective when pageCount condition exists but bookPageCount is null', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { min: 500 } },
+                    modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 10 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], null)).toBe('subjective');
+    });
+
+    test('auto-applied when pageCount exactly equals min boundary', () => {
+        const bonus = {
+            type: 'item',
+            itemData: {
+                effects: [{
+                    trigger: 'ON_QUEST_COMPLETED',
+                    condition: { pageCount: { min: 500 } },
+                    modifier: { type: 'ADD_FLAT', resource: 'inkDrops', value: 10 }
+                }]
+            }
+        };
+        expect(classifyBonusCardState(bonus, ['fantasy'], 500)).toBe('auto-applied');
     });
 });
 
@@ -383,5 +487,76 @@ describe('renderBonusCards with bookTags', () => {
         const cards = container.querySelectorAll('.quest-bonus-card');
         expect(cards.length).toBe(1);
         expect(cards[0].classList.contains('unmatched')).toBe(true);
+    });
+
+    it('renders pageCount item as auto-applied when page count meets condition', () => {
+        characterState.equippedItems = [{ name: "Bookwyrm's Scale" }];
+        document.getElementById('keeperBackground').value = '';
+
+        ui.updateEditQuestBuffsDropdown([], ['fantasy'], 600);
+
+        const container = document.getElementById('edit-quest-bonus-selection-container');
+        const cards = container.querySelectorAll('.quest-bonus-card');
+        expect(cards.length).toBe(1);
+        expect(cards[0].classList.contains('auto-applied')).toBe(true);
+    });
+
+    it('renders pageCount item as unmatched with "Needs:" page info when not met', () => {
+        characterState.equippedItems = [{ name: "Bookwyrm's Scale" }];
+        document.getElementById('keeperBackground').value = '';
+
+        ui.updateEditQuestBuffsDropdown([], ['fantasy'], 300);
+
+        const container = document.getElementById('edit-quest-bonus-selection-container');
+        const card = container.querySelector('.quest-bonus-card.unmatched');
+        expect(card).not.toBeNull();
+        const needsSection = card.querySelector('.quest-bonus-card-needs');
+        expect(needsSection).not.toBeNull();
+        expect(needsSection.textContent).toContain('500+ pages');
+    });
+
+    it('renders pageCount item as subjective when bookPageCount is null', () => {
+        characterState.equippedItems = [{ name: "Bookwyrm's Scale" }];
+        document.getElementById('keeperBackground').value = '';
+
+        ui.updateEditQuestBuffsDropdown([], ['fantasy'], null);
+
+        const container = document.getElementById('edit-quest-bonus-selection-container');
+        const cards = container.querySelectorAll('.quest-bonus-card');
+        expect(cards.length).toBe(1);
+        expect(cards[0].classList.contains('subjective')).toBe(true);
+    });
+
+    it('renders Page Sprite unmatched with "Under X pages" when condition not met', () => {
+        characterState.equippedItems = [{ name: 'Page Sprite' }];
+        document.getElementById('keeperBackground').value = '';
+
+        ui.updateEditQuestBuffsDropdown([], ['fantasy'], 400);
+
+        const container = document.getElementById('edit-quest-bonus-selection-container');
+        const card = container.querySelector('.quest-bonus-card.unmatched');
+        expect(card).not.toBeNull();
+        const needsSection = card.querySelector('.quest-bonus-card-needs');
+        expect(needsSection).not.toBeNull();
+        expect(needsSection.textContent).toContain('Under 300 pages');
+    });
+
+    it('all items become unmatched when bookTags is null (no book linked)', () => {
+        characterState.equippedItems = [
+            { name: "Librarian's Compass" },
+            { name: "Bookwyrm's Scale" },
+            { name: 'Scatter Brain Scarab' }
+        ];
+        document.getElementById('keeperBackground').value = '';
+
+        ui.updateEditQuestBuffsDropdown([], null);
+
+        const container = document.getElementById('edit-quest-bonus-selection-container');
+        const subjective = container.querySelectorAll('.quest-bonus-card.subjective');
+        const autoApplied = container.querySelectorAll('.quest-bonus-card.auto-applied');
+        const unmatched = container.querySelectorAll('.quest-bonus-card.unmatched');
+        expect(subjective.length).toBe(0);
+        expect(autoApplied.length).toBe(0);
+        expect(unmatched.length).toBe(3);
     });
 });

--- a/tests/questEditDrawer.test.js
+++ b/tests/questEditDrawer.test.js
@@ -310,9 +310,10 @@ describe('Quest Edit Drawer', () => {
         });
 
         it('should pre-select buffs that are already on the quest', () => {
-            // Use a real item from allItems that won't be filtered out
-            const testItemName = 'Pocket Dragon';
-            
+            // Scatter Brain Scarab has no tagMatch/pageCount conditions (legacy rewardModifier only),
+            // so it's subjective (toggleable) when a book is linked
+            const testItemName = 'Scatter Brain Scarab';
+
             // Add temporary buff
             characterState.temporaryBuffs = [{
                 name: 'Test Buff',
@@ -325,15 +326,19 @@ describe('Quest Edit Drawer', () => {
             // Add equipped item
             characterState.equippedItems = [{
                 name: testItemName,
-                bonus: '+20 Ink Drops',
-                type: 'Familiar'
+                bonus: 'x3 Ink Drops',
+                type: 'Wearable'
             }];
 
-            // Add a quest with buffs
+            // Link a book with tags so buff cards enter tag-aware mode (not all-greyed-out)
+            characterState[STORAGE_KEYS.BOOKS]['test-book-1'].tags = ['fantasy'];
+
+            // Add a quest with buffs linked to a book
             characterState.activeAssignments = [{
                 type: '♥ Organize the Stacks',
                 prompt: 'Fantasy',
                 book: 'Test Book',
+                bookId: 'test-book-1',
                 month: 'January',
                 year: '2024',
                 notes: '',
@@ -347,7 +352,7 @@ describe('Quest Edit Drawer', () => {
             const editBtn = document.querySelector('.edit-quest-btn[data-index="0"]');
             editBtn.click();
 
-            // Check that buffs are selected (cards + hidden JSON input)
+            // Buff and Scatter Brain Scarab have no tagMatch conditions → subjective → can be pre-selected
             const container = document.getElementById('edit-quest-bonus-selection-container');
             const buffCard = container?.querySelector('.quest-bonus-card[data-value="[Buff] Test Buff"]');
             const itemCard = container?.querySelector(`.quest-bonus-card[data-value="[Item] ${testItemName}"]`);
@@ -528,21 +533,25 @@ describe('Quest Edit Drawer', () => {
                 status: 'active'
             }];
 
-            // Use a real item from allItems that won't be filtered out
-            const testItemName = 'Pocket Dragon';
-            
+            // Scatter Brain Scarab has no tagMatch/pageCount (legacy rewardModifier only) → subjective
+            const testItemName = 'Scatter Brain Scarab';
+
             // Add equipped item
             characterState.equippedItems = [{
                 name: testItemName,
-                bonus: '+20 Ink Drops',
-                type: 'Familiar'
+                bonus: 'x3 Ink Drops',
+                type: 'Wearable'
             }];
 
-            // Add a quest without buffs
+            // Link a book so buff cards are in tag-aware mode (not all-greyed-out)
+            characterState[STORAGE_KEYS.BOOKS]['test-book-1'].tags = ['fantasy'];
+
+            // Add a quest without buffs, linked to a book
             characterState.activeAssignments = [{
                 type: '♥ Organize the Stacks',
                 prompt: 'Fantasy',
                 book: 'Test Book',
+                bookId: 'test-book-1',
                 month: 'January',
                 year: '2024',
                 notes: '',
@@ -556,7 +565,7 @@ describe('Quest Edit Drawer', () => {
             const editBtn = document.querySelector('.edit-quest-btn[data-index="0"]');
             editBtn.click();
 
-            // Select buffs (card-based)
+            // Select buffs (card-based) — these are subjective items, so toggleable
             const container = document.getElementById('edit-quest-bonus-selection-container');
             const buffCard = container?.querySelector('.quest-bonus-card[data-value="[Buff] Test Buff"]');
             const itemCard = container?.querySelector(`.quest-bonus-card[data-value="[Item] ${testItemName}"]`);


### PR DESCRIPTION
- Added support for page count conditions in the `classifyBonusCardState` function to determine if bonuses are 'auto-applied', 'unmatched', or 'subjective' based on linked book page counts.
- Updated UI rendering to display relevant page count information for unmatched cards, improving user feedback on requirements.
- Introduced new CSS styles for visual differentiation of page count needs.
- Expanded unit tests to cover new page count scenarios, ensuring robust classification logic and rendering behavior.